### PR TITLE
Add create-required-services option to SK run-x tasks

### DIFF
--- a/.github/workflows/run-dbconfigs.yaml
+++ b/.github/workflows/run-dbconfigs.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           require-redis: "true"
           require-postgres: "true"
+          create-required-services: "true"
           s3-url: "s3://com.singularkey.gsa/dev/database-configs"
           app-directory: "sk-dbconfigs"
           sk-secrets: ${{ secrets[env.SK_SECRETS] }}

--- a/.github/workflows/run-esconfigs.yaml
+++ b/.github/workflows/run-esconfigs.yaml
@@ -46,6 +46,7 @@ jobs:
         id: sk-setup
         with:
           require-elasticsearch: "true"
+          create-required-services: "true"
           s3-url: "s3://com.singularkey.gsa/dev/elasticsearch-configs"
           app-directory: "sk-esconfigs"
           sk-secrets: ${{ secrets[env.SK_SECRETS] }}


### PR DESCRIPTION
Restore the creation of required services functionality that the run-esconfigs and run-dbconfigs previously had before switching to a consolidated github action for SK deployment steps.