### PR TITLE
Disable the binary permissions step

### DIFF
--- a/.github/workflows/deploy-portal.yaml
+++ b/.github/workflows/deploy-portal.yaml
@@ -48,6 +48,7 @@ jobs:
           s3-url: "s3://com.singularkey.gsa/dev/sk-portal"
           app-directory: "sk-portal"
           sk-secrets: ${{ secrets[env.SK_SECRETS] }}
+          disable-executable: "true"
 
       - name: Deploy application
         run: |


### PR DESCRIPTION
The SK portal is one of the few services that is not a binary and thus
needs to skip adding executable permissions as part of the deployment
process.
