### PR TITLE
Disable the binary permissions step

### DIFF
--- a/.github/workflows/deploy-portal.yaml
+++ b/.github/workflows/deploy-portal.yaml
@@ -48,6 +48,7 @@ jobs:
           s3-url: "s3://com.singularkey.gsa/dev/sk-portal"
           app-directory: "sk-portal"
           sk-secrets: ${{ secrets[env.SK_SECRETS] }}
+          disable-executable: "true"
 
       - name: Deploy application
         run: |

--- a/.github/workflows/deploy-sdk.yaml
+++ b/.github/workflows/deploy-sdk.yaml
@@ -48,6 +48,7 @@ jobs:
           s3-url: "s3://com.singularkey.gsa/dev/sk-sdk"
           app-directory: "sk-sdk"
           sk-secrets: ${{ secrets[env.SK_SECRETS] }}
+          disable-executable: "true"
 
       - name: Deploy application
         run: |


### PR DESCRIPTION
The SK portal and SK SDK are some of the few services that are not a
binary and thus need to skip adding executable permissions as part
of the deployment process.