### PR TITLE
Correct the directory stucture during sk-portal deployment step

### DIFF
--- a/.github/workflows/deploy-portal.yaml
+++ b/.github/workflows/deploy-portal.yaml
@@ -53,8 +53,8 @@ jobs:
       - name: Deploy application
         run: |
           cd sk-portal
-          tar -xf build.tar.gz
-          cd build
+          tar --strip-components=1 -xf build.tar.gz
+          rm build.tar.gz
           #Replace the api endpoint url with the correct one for the environment
           find . -type f -exec sed -i 's/skdevapi/give-api-${{ steps.cf-setup.outputs.target-environment }}/g' {} +
           cf push --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }} --strategy rolling


### PR DESCRIPTION
Extract the provided build.tar.gz to the current directory, removing
additional directories altogether, and rm the tar file before pushing.
