### PR TITLE
Revert extracting the sk-portal contents to the current directory

### DIFF
--- a/.github/workflows/deploy-portal.yaml
+++ b/.github/workflows/deploy-portal.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Deploy application
         run: |
           cd sk-portal
-          tar --strip-components=1 -xf build.tar.gz
+          tar -xf build.tar.gz
           rm build.tar.gz
           #Replace the api endpoint url with the correct one for the environment
           find . -type f -exec sed -i 's/skdevapi/give-api-${{ steps.cf-setup.outputs.target-environment }}/g' {} +


### PR DESCRIPTION
The staticfile specifies that the SK portal contents are served from the
build directory. Simply extracting the tar and pushing the app will
restore the original functionality of to before switching to the
sk-setup action.
